### PR TITLE
Remove UTF-8 BOM from koan sources

### DIFF
--- a/PollyKoans/Framework/EnlightedEqualTo.cs
+++ b/PollyKoans/Framework/EnlightedEqualTo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;

--- a/PollyKoans/Properties/AssemblyInfo.cs
+++ b/PollyKoans/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/PollyKoans/_0_Sample_Koan.cs
+++ b/PollyKoans/_0_Sample_Koan.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;

--- a/PollyKoans/_1_Retry_Koans.cs
+++ b/PollyKoans/_1_Retry_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;

--- a/PollyKoans/_2_Fallback_Koans.cs
+++ b/PollyKoans/_2_Fallback_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/PollyKoans/_3_Timeout_Koans.cs
+++ b/PollyKoans/_3_Timeout_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/PollyKoans/_4_Bulkhead_Koans.cs
+++ b/PollyKoans/_4_Bulkhead_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/PollyKoans/_5_Policy_Wrap_Koans.cs
+++ b/PollyKoans/_5_Policy_Wrap_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Polly;
 using PollyKoans.Framework;

--- a/PollyKoans/_6_Circuit_Breaker_Koans.cs
+++ b/PollyKoans/_6_Circuit_Breaker_Koans.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Polly;


### PR DESCRIPTION
## Summary
- strip BOM characters from all C# sources to avoid encoding artifacts

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68546d3b89ec832f8d2f6aebeb1b85bf